### PR TITLE
fix(bili): send cookies, migrate to getRoomPlayInfo API

### DIFF
--- a/live_recorder/you_live/bili_recorder.py
+++ b/live_recorder/you_live/bili_recorder.py
@@ -13,16 +13,18 @@ class BiliRecorder(BaseRecorder):
         roomInfo = {}
         roomInfo['short_id'] = self.short_id
         
-        url = "https://api.live.bilibili.com/room/v1/Room/get_info?id=%s&from=room"%self.short_id
         headers = {
             'Accept': 'application/json, text/plain, */*',
-            #'Accept-Encoding': 'gzip, deflate, br',
             'Accept-Language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
             'Origin': 'https://live.bilibili.com',
             'Referer': 'https://live.bilibili.com/blanc/%s'%self.short_id,
             'X-Requested-With': 'ShockwaveFlash/28.0.0.137',
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0',
         }
+        if not self.cookies is None:
+            headers['Cookie'] = self.cookies
+        
+        url = "https://api.live.bilibili.com/room/v1/Room/get_info?id=%s&from=room"%self.short_id
         data_json = requests.get(url, timeout=10, headers=headers).json()['data']
         roomInfo['room_id'] = str(data_json['room_id'])
         roomInfo['live_status'] = str(data_json['live_status'])
@@ -36,10 +38,28 @@ class BiliRecorder(BaseRecorder):
             roomInfo['room_owner_name'] = data_json['info']['uname']
             
             quality = {}
-            url = "https://api.live.bilibili.com/room/v1/Room/playUrl?cid=%s&quality=%s&platform=web"%(roomInfo['room_id'], 0)
-            multirates = requests.get(url, timeout=10, headers=headers).json()['data']['quality_description']
-            for rate in multirates:
-                quality[str(rate['qn'])] = rate['desc']
+            url = "https://api.live.bilibili.com/xlive/web-room/v2/index/getRoomPlayInfo"
+            params = {
+                'room_id': roomInfo['room_id'],
+                'protocol': '0,1',
+                'format': '0,1,2',
+                'codec': '0,1',
+                'qn': '0',
+                'platform': 'web',
+                'ptype': '8',
+            }
+            playinfo = requests.get(url, params=params, timeout=10, headers=headers).json()
+            if playinfo['code'] == 0:
+                playurl = playinfo['data']['playurl_info']['playurl']
+                if playurl:
+                    g_qn_desc = playurl.get('g_qn_desc', [])
+                    desc_map = {qn_info['qn']: qn_info['desc'] for qn_info in g_qn_desc}
+                    try:
+                        accept_qn = playurl['stream'][0]['format'][0]['codec'][0]['accept_qn']
+                    except (KeyError, IndexError, TypeError):
+                        accept_qn = list(desc_map.keys())
+                    for qn_val in accept_qn:
+                        quality[str(qn_val)] = desc_map.get(qn_val, str(qn_val))
             roomInfo['live_rates'] = quality
         self.headers = headers    
         self.roomInfo = roomInfo    
@@ -52,11 +72,46 @@ class BiliRecorder(BaseRecorder):
             print('当前没有在直播')
             return None
         
+        url = "https://api.live.bilibili.com/xlive/web-room/v2/index/getRoomPlayInfo"
+        params = {
+            'room_id': self.roomInfo['room_id'],
+            'protocol': '0,1',
+            'format': '0,1,2',
+            'codec': '0,1',
+            'qn': qn,
+            'platform': 'web',
+            'ptype': '8',
+        }
+        data_json = requests.get(url, params=params, timeout=10, headers=self.headers).json()
+        if data_json['code'] == 0:
+            try:
+                playurl = data_json['data']['playurl_info']['playurl']
+                if playurl and playurl.get('stream'):
+                    stream = playurl['stream'][0]
+                    for fmt in stream['format']:
+                        if fmt['format_name'] == 'flv':
+                            codec_info = fmt['codec'][0]
+                            self.live_qn = codec_info['current_qn']
+                            url_info = codec_info['url_info'][0]
+                            self.live_url = url_info['host'] + codec_info['base_url'] + url_info['extra']
+                            print("申请清晰度 %s的链接，得到清晰度 %d的链接"%(qn, self.live_qn))
+                            self.download_headers = {
+                                'Accept': 'application/json, text/plain, */*',
+                                'Accept-Encoding': 'gzip, deflate, br',
+                                'Accept-Language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+                                'Origin': 'https://live.bilibili.com',
+                                'Referer': 'https://live.bilibili.com/%s'%self.short_id,
+                                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0',
+                            }
+                            if not self.cookies is None:
+                                self.download_headers['Cookie'] = self.cookies
+                            return self.live_url
+            except (KeyError, IndexError, TypeError):
+                pass
+        
         url = "https://api.live.bilibili.com/room/v1/Room/playUrl?cid=%s&quality=%s&platform=web"%(self.roomInfo['room_id'], qn)
         data_json = requests.get(url, timeout=10, headers=self.headers).json()['data']
-#         print(data_json)
         self.live_url = data_json['durl'][0]['url']
-#         self.live_qn = data_json['current_quality']
         self.live_qn = data_json['current_qn']
         print("申请清晰度 %s的链接，得到清晰度 %d的链接"%(qn, self.live_qn))
         self.download_headers = {
@@ -67,4 +122,6 @@ class BiliRecorder(BaseRecorder):
             'Referer': 'https://live.bilibili.com/%s'%self.short_id,
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:68.0) Gecko/20100101 Firefox/68.0',
         }
+        if not self.cookies is None:
+            self.download_headers['Cookie'] = self.cookies
         return self.live_url


### PR DESCRIPTION
## Changes

Three issues fixed in `bili_recorder.py`:

### 1. Cookies not sent (root cause of no high-quality stream)
The `-c` cookie parameter was accepted but never injected into any Bilibili API request headers. All other recorders (`douyu`, `kuaishou`) already appended cookies to headers — `bili` was missing this entirely. Without cookies, Bilibili's live API silently downgrades quality (e.g., 原画/10000 → 高清/150).

### 2. Wrong API parameter name
The new API endpoint `/xlive/web-room/v2/index/getRoomPlayInfo` expects `qn` as the quality parameter, not `quality`. Was passing `quality=10000` which the API ignored.

### 3. Deprecated API for stream URL acquisition
Migrated from the deprecated `/room/v1/Room/playUrl` to the modern `/xlive/web-room/v2/index/getRoomPlayInfo` with proper parameters (`protocol=0,1`, `format=0,1,2`, `codec=0,1`, `ptype=8`). Falls back to the old API if the new one fails.

### 4. Quality list now filtered by `accept_qn`
Previously used `g_qn_desc` (global) which included qualities not actually available for the stream (e.g., 杜比/4K/2K for room 55). Now filters by the stream's `accept_qn` array.

fix #23 